### PR TITLE
fix: add feature flag for ruzstd deps

### DIFF
--- a/squinter/src/squashfs/compressed.rs
+++ b/squinter/src/squashfs/compressed.rs
@@ -9,7 +9,9 @@ use flate2::read::ZlibDecoder;
 #[cfg(feature = "lzma-rs")]
 use lzma_rs::xz_decompress;
 
+#[cfg(feature = "ruzstd")]
 use ruzstd::decoding::errors::FrameDecoderError;
+#[cfg(feature = "ruzstd")]
 use ruzstd::decoding::BlockDecodingStrategy;
 #[cfg(feature = "ruzstd")]
 use ruzstd::decoding::FrameDecoder;


### PR DESCRIPTION
When we disable feature `zstd`, the compiler will cry with the following information

```
12 | use ruzstd::decoding::errors::FrameDecoderError;
   |     ^^^^^^ use of undeclared crate or module `ruzstd`
```

This is because the ruzstd is disabled but the code still imports it. This patch fixes this by add a feature flag.